### PR TITLE
Changed resp.local() calls to resp.locals()

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -99,20 +99,22 @@ exports.abide = function (options) {
         lang = 'db-LB'; // What? http://www.youtube.com/watch?v=rJLnGjhPT1Q
     }
 
-    resp.local('lang', lang);
+    resp.locals('lang', lang);
 
     // BIDI support, which direction does text flow?
     lang_dir = BIDI_RTL_LANGS.indexOf(lang) >= 0 ? 'rtl' : 'ltr';
-    resp.local('lang_dir', lang_dir);
+    resp.locals('lang_dir', lang_dir);
     req.lang = lang;
 
     locale = localeFrom(lang);
 
-    resp.local('locale', locale);
+    resp.locals('locale', locale);
     req.locale = locale;
 
-    resp.local('format', format);
+    resp.locals('format', format);
     req.format = format;
+
+    resp.locals('format', format);
 
     if (mo_cache[locale].mo_exists) {
       if (mo_cache[locale].gt === null) {
@@ -123,16 +125,16 @@ exports.abide = function (options) {
         mo_cache[locale].gt.textdomain(locale);
       }
       var gt = mo_cache[locale].gt;
-      resp.local(options.gettext_alias, gt.gettext.bind(gt));
+      resp.locals(options.gettext_alias, gt.gettext.bind(gt));
       req.gettext = gt.gettext.bind(gt);
-      resp.local(options.ngettext_alias, gt.ngettext.bind(gt));
+      resp.locals(options.ngettext_alias, gt.ngettext.bind(gt));
       req.ngettext = gt.ngettext.bind(gt);
    } else {
       // en-US in a non gettext environment... fake it
       var identity = function (a, b) { return a; };
-      resp.local(options.gettext_alias, identity);
+      resp.locals(options.gettext_alias, identity);
       req.gettext = identity;
-      resp.local(options.ngettext_alias, identity);
+      resp.locals(options.ngettext_alias, identity);
       req.ngettext = identity;
     }
     next();


### PR DESCRIPTION
resp.local() does not appear to exist in express 3.0.0 beta7 .  resp.locals() does the same thing though, and it can take a full object.  Just changed the resp.local() calls to resp.locals().

Express 3.0.0 is still in beta, so you may not want to merge this pull request yet.  But when you're ready, here it is.  With this change, all my tests appear to work.
