### PR TITLE
Added support for Key-Value JSON Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ The `locale_on_url` option is off by default.
 
 ## Translation files
 
-The ``i18n-abide`` module can use either PO/POT files, which get transformed to JSON via provided command line tools, or [PLIST](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man5/plist.5.html) (i.e., XML) files, which require no transformation prior to use.
+The ``i18n-abide`` module currently supports three file formats. PO/POT files, which get transformed to JSON via provided command line tools, [PLIST](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man5/plist.5.html) (i.e., XML) files, which require no transformation prior to use, and [JSON](https://developer.mozilla.org/en/docs/JSON) (JavaScript Object Notation) a key-value JSON type. 
+
+NOTE: The PO/POT files are also transformed into .JSON, but do not follow the same layout as a simple key-value pair JSON files.
 
 By default PO/POT files are used. This can be changed during setup:
 

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -58,15 +58,17 @@ exports.abide = function(options) {
   if (! options.translation_directory) options.translation_directory = 'l18n/';
   if (! options.logger)                options.logger = console;
 
-  // We expect to use PO->json files, unless configured to use plist.
-  options.translation_type = options.translation_type === 'plist' ? 'plist' : 'json';
+  // We expect to use PO->json files, unless configured to use another format.
+   options.translation_type = options.translation_type || 'po';
   // Only check URL for locale if told to do so.
   options.locale_on_url = options.locale_on_url === true;
 
   logger = options.logger;
 
   function messages_file_path(locale) {
-    var filename = 'messages.' + options.translation_type;
+    // check if the option is 'key-value-json' if so the file format would be 'json' instead
+    var file_format = options.translation_type == 'plist' ? 'plist' : 'json'
+    var filename = 'messages.' + file_format;
     return path.resolve(path.join(__dirname, '..', '..', '..'),
                         options.translation_directory,
                         path.join(locale, filename));
@@ -77,6 +79,9 @@ exports.abide = function(options) {
 
     if (options.translation_type === 'plist') {
       return plist.parseFileSync(filepath);
+    }
+    else if (options.translation_type === 'key-value-json') {
+      return require(filepath);
     }
     // PO->json file
     else {
@@ -210,7 +215,7 @@ exports.abide = function(options) {
     } else if (translations[locale]) {
       gt = function(sid) {
         // The plist and PO->json files are in a slightly different format.
-        if (options.translation_type === 'plist') {
+        if (options.translation_type === 'plist' || options.translation_type === 'key-value-json') {
           if (translations[locale][sid] && translations[locale][sid].length) {
             return translations[locale][sid];
           } else {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Austin King <shout@ozten.com> (http://ozten.com)",
   "name": "i18n-abide",
   "description": "Express/connect module for Node i18n and l10n support",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "homepage": "https://github.com/mozilla/i18n-abide",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Recently Transifex added a support for "Key-Value-JSON" format and we thought that i18n-abide should also have that file support because it will be very useful for anyone who wants to localize their app using .json file format.

We have added a support for "key":"value" JSON type to the i18n-abide, and now the option in the type can be "key-value-json"
