### PR TITLE
Issue 42 rename format

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -47,7 +47,7 @@ Another way to override locale settings is directly via the API.
 
 You can set locale in the scope of a single request.
 The following example shows how to set the locale of the request to `zh_TW`
-(Traditional Chinese): 
+(Traditional Chinese):
 
     exports.homepage = function(req, resp) {
       req.setLocale('zh_TW');
@@ -73,3 +73,21 @@ The `translation_type` option will cause `i18n-abide` to look for files named
 `messages.plist` in locale directories beneath your `translation_directory` root.
 For example, the `es` language listed above should be located at
 `i18n/es/messages.plist`.
+
+## format_fn_name Option
+
+For compatibility with `express-resource` and other apps,
+you may use the `format_fn_name` option to rename the `format` function.
+
+Example:
+
+    app.use(i18n.abide({format_fn_name: 'i18nformat'}));
+
+    app.get('/foo', function(req, res) {
+      res.render('bar', {
+        greeting: req.i18nformat("%s %s!", ["Hello", "World"]);
+      });
+    });
+
+    # in bar.ejs
+    <p><%= i18nformat(gettext("Please see %s"), ["https://example.com"]) %></p>

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -59,7 +59,7 @@ exports.abide = function(options) {
   if (! options.logger)                options.logger = console;
 
   // We expect to use PO->json files, unless configured to use another format.
-   options.translation_type = options.translation_type || 'po';
+  options.translation_type = options.translation_type || 'po';
   // Only check URL for locale if told to do so.
   options.locale_on_url = options.locale_on_url === true;
 
@@ -186,15 +186,21 @@ exports.abide = function(options) {
     locals.locale = locale;
     req.locale = locale;
 
+    var formatFnName = 'format';
     if (!! locals.format || !! req.format) {
-      console.error("It appears you are using middleware which " +
-        "already sets a variable 'format' on either the request " +
-        "or reponse. Please use format-fn-name in options to " +
-        "override this setting.");
-      throw new Error("Bad Config - override format-fn-name");
+      if (!! options.format_fn_name) {
+        formatFnName = options.format_fn_name;
+      } else {
+        console.error("It appears you are using middleware which " +
+          "already sets a variable 'format' on either the request " +
+          "or reponse. Please use format_fn_name in options to " +
+          "override this setting.");
+        throw new Error("Bad Config - override format_fn_name");
+      }
+
     }
-    locals.format = format;
-    req.format = format;
+    locals[formatFnName] = format;
+    req[formatFnName] = format;
 
     locals.setLocale = function(assignedLocale) {
       if (translations[assignedLocale]) {


### PR DESCRIPTION
Adds tests for normal operation and throwing errors for `format` function collision.

Adds `format_fn_name` to options and renames `req` and `res` context variable for `format`.
