### PR TITLE
Add getStrings(lang) to i18n module to allow access to translations externally.

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -28,11 +28,32 @@ const BIDI_RTL_LANGS = ['ar', DAVID_B_LABYRN, 'fa', 'he'];
 const JS_PRE_LEN = 24;
 const JS_POST_LEN = 3;
 
-var translations = {};
-var logger;
+var translations = {},
+    default_lang = 'en-US',
+    translation_type = 'po',
+    logger;
 
 // forward references
 var localeFrom, parseAcceptLanguage, bestLanguage, format, languageFrom;
+
+function gettext(sid, locale) {
+  // The plist and PO->json files are in a slightly different format.
+  if (translation_type === 'plist' || translation_type === 'key-value-json') {
+    if (translations[locale][sid] && translations[locale][sid].length) {
+      return translations[locale][sid];
+    } else {
+      // Return the default lang's string if missing in the translation.
+      return (translations[default_lang][sid] || sid);
+    }
+  }
+  // PO->json file
+  else {
+    if (translations[locale][sid] && translations[locale][sid][1].length) {
+      return translations[locale][sid][1];
+    }
+  }
+  return sid;
+}
 
 /**
  * Connect middleware which is i18n aware.
@@ -63,6 +84,8 @@ exports.abide = function(options) {
   // Only check URL for locale if told to do so.
   options.locale_on_url = options.locale_on_url === true;
 
+  default_lang = options.default_lang;
+  translation_type = options.translation_type;
   logger = options.logger;
 
   function messages_file_path(locale) {
@@ -225,22 +248,7 @@ exports.abide = function(options) {
       locals.lang = DAVID_B_LABYRN;
     } else if (translations[locale]) {
       gt = function(sid) {
-        // The plist and PO->json files are in a slightly different format.
-        if (options.translation_type === 'plist' || options.translation_type === 'key-value-json') {
-          if (translations[locale][sid] && translations[locale][sid].length) {
-            return translations[locale][sid];
-          } else {
-            // Return the default lang's string if missing in the translation.
-            return (translations[options.default_lang][sid] || sid);
-          }
-        }
-        // PO->json file
-        else {
-          if (translations[locale][sid] && translations[locale][sid][1].length) {
-            return translations[locale][sid][1];
-          }
-        }
-        return sid;
+        return gettext(sid, locale);
       };
     } else {
       // default lang in a non gettext environment... fake it
@@ -301,7 +309,6 @@ exports.parseAcceptLanguage = parseAcceptLanguage = function(header) {
  // languages must be a sorted list, the first match is returned.
 exports.bestLanguage = bestLanguage = function(languages, supported_languages, defaultLanguage) {
   var lower = supported_languages.map(function(l) { return l.toLowerCase(); });
-  console.log(languages, supported_languages, defaultLanguage);
   for(var i=0; i < languages.length; i++) {
     var lq = languages[i];
     if (lower.indexOf(lq.lang.toLowerCase()) !== -1) {
@@ -389,4 +396,23 @@ exports.format = format = function(fmt, obj, named) {
  */
 exports.getLocales = function() {
   return Object.keys(translations);
+};
+
+/**
+ * Returns a copy of the translated strings for the given language.
+ */
+exports.getStrings = function(lang) {
+  var locale = localeFrom(lang),
+      translated = translations[locale],
+      strings = {};
+  if (!translated) {
+    return strings;
+  }
+
+  // Copy the translation pairs and return. We copy vs. simply returning
+  // so we can maintain the translations internally, and count on them.
+  Object.keys(translated).forEach(function(key) {
+    strings[key] = gettext(key, locale);
+  });
+  return strings;
 };

--- a/tests/i18n-tests.js
+++ b/tests/i18n-tests.js
@@ -385,6 +385,34 @@ suite.addBatch({
   }
 });
 
+suite.addBatch({
+  "i18n.abide correctly hands out strings for known langs via getStrings": {
+    topic: function(){
+      // Create a new, stand-alone i18n instance (i19n) so we can isolate from other tests
+      var i19n = require('../lib/i18n');
+      i19n.abide({
+        supported_languages: [ 'en', 'fr', 'de' ],
+        default_lang: 'en',
+        translation_type: 'key-value-json',
+        translation_directory: path.join(__dirname, 'locale')
+      });
+      return i19n;
+    },
+    "gives en strings for `en` lang": function(i19n) {
+      var language = i19n.getStrings('en').language;
+      assert.equal(language, "English");
+    },
+    "gives fr strings for `fr` lang": function(i19n) {
+      var language = i19n.getStrings('fr').language;
+      assert.equal(language, "French");
+    },
+    "gives de strings for `de` lang": function(i19n) {
+      var language = i19n.getStrings('de').language;
+      assert.equal(language, "German");
+    }
+  }
+});
+
 // run or export the suite.
 if (process.argv[1] === __filename) suite.run();
 else suite.export(module);


### PR DESCRIPTION
This adds a new module function, `getStrings`, which takes a language, and gives back the translated strings for that language's locale.  It's useful for cases where a particular string catalog needs to get sent to a client at run-time.  I've also included tests.
