### PR TITLE
Upgrade jsxgettext to 0.3.3 in order to fix Jade tpl engine support

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Austin King <shout@ozten.com> (http://ozten.com)",
   "name": "i18n-abide",
   "description": "Express/connect module for Node i18n and l10n support",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "homepage": "https://github.com/mozilla/i18n-abide",
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
   "dependencies": {
     "async": "0.1.22",
     "gobbledygook": "0.0.3",
-    "jsxgettext": "0.3.2",
+    "jsxgettext": "0.3.3",
     "optimist": "0.3.4",
     "plist": "0.4.3"
     },


### PR DESCRIPTION
Sorry, for Jade templating support I needed to first fix jsxgettext ;) 
