### PR TITLE
Use on tarball, not Git checkout, for gobbledygook

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "async": "0.1.22",
-    "gobbledygook": "git://github.com/lloyd/gobbledygook.git#3540426",
+    "gobbledygook": "https://github.com/lloyd/gobbledygook/tarball/354042684056e57ca77f036989e907707a36cff2",
     "jsxgettext": "0.3.9",
     "optimist": "0.3.4",
     "plist": "0.4.3"


### PR DESCRIPTION
Fixes #63
