### PR TITLE
extract-pot: Fix for 'Unsupported language: JS' error

### DIFF
--- a/bin/extract-pot
+++ b/bin/extract-pot
@@ -42,7 +42,7 @@ process.chdir(path.dirname(__dirname));
 
 var jsxGettextPath = path.join(__dirname, '../node_modules/.bin/jsxgettext');
 
-var jsCmd = jsxGettextPath + ' %s --keyword=_ -L JS ' +
+var jsCmd = jsxGettextPath + ' %s --keyword=_ -l JavaScript ' +
 '--output-dir=%s/templates/LC_MESSAGES --from-code=utf-8 --output=messages.pot ' +
 '`find %s -name \'*.js\' | grep -v node_modules | grep -v .git';
 


### PR DESCRIPTION
Call of this binary without parameters on nunjucks app leads to error.
This discussed in zaach/jsxgettext#47 and changes proposed there helps.
