### PR TITLE
Use locale domain `messages` in gettext.js

### DIFF
--- a/static/gettext.js
+++ b/static/gettext.js
@@ -6,11 +6,11 @@
 (function() {
   "use strict";
 
-  function Gettext(params) {
+  function Gettext() {
       return {
         gettext: function (msgid) {
-          if (json_locale_data && json_locale_data["client"]) {
-          var dict = json_locale_data["client"];
+          if (json_locale_data && json_locale_data.messages) {
+          var dict = json_locale_data.messages;
             if (dict[msgid] && dict[msgid].length >= 2 &&
                 dict[msgid][1].trim() != "") {
               return dict[msgid][1];
@@ -37,7 +37,7 @@
         "domain" : "client",
         "locale_data" : json_locale_data
   };
-  var gt = new Gettext(params);
+  var gt = new Gettext();
   window.gettext = gt.gettext.bind(gt);
   window.format = gt.format.bind(gt);
 

--- a/static/gettext.js
+++ b/static/gettext.js
@@ -7,36 +7,33 @@
   "use strict";
 
   function Gettext() {
-      return {
+    return {
         gettext: function (msgid) {
           if (json_locale_data && json_locale_data.messages) {
-          var dict = json_locale_data.messages;
+            var dict = json_locale_data.messages;
             if (dict[msgid] && dict[msgid].length >= 2 &&
-                dict[msgid][1].trim() != "") {
+                dict[msgid][1].trim() !== "") {
               return dict[msgid][1];
             }
-        }
-        return msgid;
+          }
+          return msgid;
         },
         // See lib/i18n.js format docs
         format: function (fmt, obj, named) {
-          if (! fmt) return "";
+          if (! fmt) {
+            return "";
+          }
           if (! fmt.replace) {
             return fmt;
           }
           if (named) {
-            return fmt.replace(/%\(\w+\)s/g, function(match){return String(obj[match.slice(2,-2)])});
+            return fmt.replace(/%\(\w+\)s/g, function(match){return String(obj[match.slice(2,-2)]);});
           } else {
-            return fmt.replace(/%s/g, function(match){return String(obj.shift())});
+            return fmt.replace(/%s/g, function(){return String(obj.shift());});
           }
         }
       };
-  };
-
-  var params = {
-        "domain" : "client",
-        "locale_data" : json_locale_data
-  };
+  }
   var gt = new Gettext();
   window.gettext = gt.gettext.bind(gt);
   window.format = gt.format.bind(gt);


### PR DESCRIPTION
Was hoping to use `gettext.js` in conjunction with grunt-i18n-abide.

This pull:
* removes the domain `client` and uses the colloquial domain `messages`
* synchronizes what is produced with `abidecompile` - [relevant source](https://github.com/mozilla/grunt-i18n-abide/blob/d5da93cb3ab31b5e95e5c17383afe09cd903b4ae/tasks/abidecompile.js#L72)
* fixes linting errors



