### PR TITLE
Allow setting the locale back to the default lang.

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -201,7 +201,8 @@ exports.abide = function(options) {
     req[formatFnName] = format;
 
     locals.setLocale = function(assignedLocale) {
-      if (translations[assignedLocale]) {
+      var assignedLang = languageFrom(assignedLocale);
+      if (translations[assignedLocale] || assignedLang === options.default_lang) {
         locale = assignedLocale;
 
         var newLocals = {};
@@ -209,7 +210,7 @@ exports.abide = function(options) {
         newLocals.locale = assignedLocale;
         req.locale = assignedLocale;
 
-        newLocals.lang = languageFrom(assignedLocale);
+        newLocals.lang = assignedLang;
         req.lang = newLocals.lang;
 
         newLocals.lang_dir = BIDI_RTL_LANGS.indexOf(newLocals.lang) >= 0 ? 'rtl' : 'ltr';
@@ -229,8 +230,13 @@ exports.abide = function(options) {
     if (lang.toLowerCase() === DAVID_B_LABYRN.toLowerCase()) {
       gt = gobbledygook;
       locals.lang = DAVID_B_LABYRN;
-    } else if (translations[locale]) {
+    } else {
       gt = function(sid) {
+        // default lang in a non gettext environment... fake it
+        if (!translations[locale]) {
+          return sid;
+        }
+
         // The plist and PO->json files are in a slightly different format.
         if (options.translation_type === 'plist' || options.translation_type === 'key-value-json') {
           if (translations[locale][sid] && translations[locale][sid].length) {
@@ -248,9 +254,6 @@ exports.abide = function(options) {
         }
         return sid;
       };
-    } else {
-      // default lang in a non gettext environment... fake it
-      gt = function(a) { return a; };
     }
     locals[options.gettext_alias] =  gt;
     req.gettext = gt;


### PR DESCRIPTION
This fixes two issues: It wasn't possible to `setLocale` to the default lang, this changes that. Additionally if you ever changed locale from a default to a non-default (or vice-versa) locale the `gettext` method would be incorrect.